### PR TITLE
Enable Binance-style order parameters

### DIFF
--- a/Orders/demo_ada.tsv
+++ b/Orders/demo_ada.tsv
@@ -1,4 +1,4 @@
-name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	q	tp	prix	hook
+name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	quantity	tp	prix	hook
 
 # Test (primary) orders types OK
 # M market orders

--- a/Orders/xbt_bk.tsv
+++ b/Orders/xbt_bk.tsv
@@ -1,4 +1,4 @@
-name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	q	tp	prix	hook
+name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	quantity	tp	prix	hook
 # buy  
 ################
 XTop	0 5440	1			sell	S		S-		qAt%pA	2000	2.6	7995 8009

--- a/Orders/xbt_test.tsv
+++ b/Orders/xbt_test.tsv
@@ -1,4 +1,4 @@
-name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	q	tp	prix	hook
+name	tps_run	essais	tOut	pause	side	oType	oDelta	tType	tDelta	atype	quantity	tp	prix	hook
 # buy  
 # #### vvvv
 

--- a/kolaBot/kola/utils/constantes.py
+++ b/kolaBot/kola/utils/constantes.py
@@ -6,9 +6,11 @@ EXECOLS = [
     "orderID",
     "clOrdID",
     "side",
-    "orderQty",
+    "orderQty",  # BitMEX
+    "quantity",  # Binance
     "price",
-    "stopPx",
+    "stopPx",  # BitMEX
+    "stopPrice",  # Binance
     "execType",
     "ordType",
     "execInst",

--- a/kolaBot/kola/utils/orderfunc.py
+++ b/kolaBot/kola/utils/orderfunc.py
@@ -78,6 +78,22 @@ def get_abbv_from_ID(oClOrdID_: str):
     return oClOrdID_.split(ORDERID_PREFIX)[-1].split("-O")[0]
 
 
+def normalize_order_dict(order: dict) -> dict:
+    """Normalize order keys between BitMEX and Binance styles.
+
+    Converts ``quantity`` to ``orderQty`` and ``stopPrice`` to ``stopPx``
+    when the BitMEX style keys are missing.  The original dictionary is
+    modified and returned for convenience.
+    """
+
+    if "orderQty" not in order and "quantity" in order:
+        order["orderQty"] = order.pop("quantity")
+    if "stopPx" not in order and "stopPrice" in order:
+        order["stopPx"] = order.pop("stopPrice")
+
+    return order
+
+
 # @log_args()
 def create_order(
     side, _q, opType, ordtype, execinst, prices=None, absdelta=0.5, text=None

--- a/kolaBot/multi_kola.py
+++ b/kolaBot/multi_kola.py
@@ -591,7 +591,7 @@ def coerce_types(s):
         "timeout": coerce_to("int", s.tOut),
         "side": s.side.strip(),
         "prix": handle_tuple(s.prix, s.atype.strip()),
-        "q": coerce_to("int", s.q),
+        "q": coerce_to("int", s["quantity"] if "quantity" in s else s.q),
         "tp": coerce_to("float", s.tp),
         "atype": s.atype.strip(),
         "oType": s.oType.strip(),


### PR DESCRIPTION
## Summary
- support Binance-style `quantity` and `stopPrice` in order helpers
- normalize order dictionary keys
- update order parsing to read `quantity` column
- allow chronos to read `quantity` and `stopPrice`
- include quantity and stopPrice in constants
- update TSV headers to use `quantity`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m py_compile $(git ls-files '*.py')`