### PR TITLE
Make RuntimeState.metadata immutable in frozen dataclass

### DIFF
--- a/kolabi/shared/core/runtime_types.py
+++ b/kolabi/shared/core/runtime_types.py
@@ -13,10 +13,11 @@ Transitional: yes, includes compatibility aliases while legacy surfaces migrate.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import Iterable, NewType, Protocol, TypedDict
+from typing import Iterable, Mapping, NewType, Protocol, TypedDict
 
 DecimalLike = Decimal | int | float | str
 
@@ -339,4 +340,4 @@ class RuntimeState:
     active_order_id: ClientOrderId | None = None
     active_exchange_order_id: ExchangeOrderId | None = None
     status: OrderStatus | None = None
-    metadata: dict[str, str] = field(default_factory=dict)
+    metadata: Mapping[str, str] = field(default_factory=lambda: MappingProxyType({}))


### PR DESCRIPTION
### Motivation
- Prevent a mutable default from living inside a frozen dataclass by making `RuntimeState.metadata` immutable to avoid accidental mutation and to reflect intended immutability.

### Description
- Change `RuntimeState.metadata` annotation from `dict[str, str]` to `Mapping[str, str]` in `kolabi/shared/core/runtime_types.py`.
- Provide an immutable default via `field(default_factory=lambda: MappingProxyType({}))` so the frozen dataclass cannot be mutated at runtime.
- Add the required imports for `Mapping` and `MappingProxyType` and update the typing imports accordingly.

### Testing
- Ran `pytest tests/core/test_runtime_commands.py -q`, which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d83684e6483238cc002b09d73334d)